### PR TITLE
fixed bug 53106

### DIFF
--- a/products/ASC.Files/Core/Services/WCFService/FileOperations/FileOperationsManager.cs
+++ b/products/ASC.Files/Core/Services/WCFService/FileOperations/FileOperationsManager.cs
@@ -233,6 +233,21 @@ namespace ASC.Web.Files.Services.WCFService.FileOperations
                         resultString.Add(val, item.Value);
                     }
                 }
+                else if (item.Key.ValueKind == JsonValueKind.Object)
+                {
+                    var key = item.Key.GetProperty("key");
+
+                    var val = item.Key.GetProperty("value").GetString();
+
+                    if (key.ValueKind == JsonValueKind.Number)
+                    {
+                        resultInt.Add(key.GetInt32(), val);
+                    }
+                    else
+                    {
+                        resultString.Add(key.GetString(), val);
+                    }
+                }
             }
 
             return (resultInt, resultString);


### PR DESCRIPTION
supported body format as

{"fileIds":[{"key":53,"value":null},{"key":52,"value":".csv"}],"folderIds":[]}

