### PR TITLE
Bugfix/calendar

### DIFF
--- a/packages/components/calendar/calendar.stories.js
+++ b/packages/components/calendar/calendar.stories.js
@@ -9,7 +9,6 @@ export default {
     maxDate: { control: "date" },
     minDate: { control: "date" },
     initialDate: { control: "date" },
-    selectedDate: { control: "date" },
     locale: {
       type: "select",
       options: [
@@ -70,7 +69,4 @@ Default.args = {
   locale: "en",
   maxDate: new Date(new Date().getFullYear() + 1 + "/01/01"),
   minDate: new Date("1970/01/01"),
-  initialDate: new Date(),
-  selectedDate: new Date(),
-  setSelectedDate: () => {},
 };

--- a/packages/components/calendar/styled-components/DateItem.js
+++ b/packages/components/calendar/styled-components/DateItem.js
@@ -31,10 +31,5 @@ export const DateItem = styled.button`
         ? "transparent"
         : props.theme.calendar.onHoverBackground};
   }
-
-  :focus {
-    color: #4781d1;
-    border: 2px solid #4781d1;
-  }
 `;
 DateItem.defaultProps = { theme: Base };


### PR DESCRIPTION
- The focus selector on a date was deleted to fix the visual double-date selection
- selectedDate, setSelectedDate, and initialDate arguments were deleted as default in storybook