### PR TITLE
bugfix/fix-floating-button

### DIFF
--- a/packages/common/components/Section/index.js
+++ b/packages/common/components/Section/index.js
@@ -256,6 +256,9 @@ const Section = (props) => {
                     icon={secondaryProgressBarIcon}
                     percent={secondaryProgressBarValue}
                     alert={showSecondaryButtonAlert}
+                    showTwoProgress={
+                      showPrimaryProgressBar && showSecondaryProgressBar
+                    }
                   />
                 </>
               ) : showPrimaryProgressBar && !showSecondaryProgressBar ? (


### PR DESCRIPTION
Fixed when several file operations are running at the same time (deleting files and downloading) the floating download button ceases to be iterative, does not click.