### PR TITLE
fix Bug 63005 - Fix build problems, .zst compression and shlib dependency 

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   build_deb:
     name: DEB packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: write
       
@@ -53,7 +53,7 @@ jobs:
           sudo apt install -y dotnet-sdk-7.0 yarn nodejs dh-make rename dpkg-sig lintian
           sudo npm install -g json
           echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
-          echo "VERSION=$(echo "${{ github.ref }}" | grep  -oP '\d+\.\d+\.\d+' || echo "1.0.0")" >> $GITHUB_OUTPUT
+          echo "VERSION=$(echo "${{ github.ref }}" | grep  -oP '\d+\.\d+\.\d+' || echo "1.1.0")" >> $GITHUB_OUTPUT
           
       - name: Build
         shell: bash
@@ -82,7 +82,7 @@ jobs:
           
   build_rpm:
     name: RPM packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: write
  

--- a/build/install/deb/debian/rules
+++ b/build/install/deb/debian/rules
@@ -60,7 +60,10 @@ override_dh_strip:
 	dh_strip -Xarm --no-automatic-dbgsym
 
 override_dh_shlibdeps:
-	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info -Xarm -Xkafka
+	dh_shlibdeps -Xarm -Xkafka -- -xlibgcc-s1 --ignore-missing-info -xlibgcc1
+
+override_dh_builddeb:
+	dh_builddeb -- -Zxz
 
 override_dh_installinit:
 # don't do anything, silences lintian warnings "init.d-script-not-included-in-package"


### PR DESCRIPTION
- Override dh_shlibdeps with preferred passing parameters option to dpkg-shlibdeps, also fixing a bug with libgcc dependency 
- Override dh_builddeb to compress related data to 'xz' - widely used compression algorithm in Debian packages, known for its high compression ratio