### PR TITLE
Fix page crash

### DIFF
--- a/packages/client/src/components/panels/NewFilesPanel/index.js
+++ b/packages/client/src/components/panels/NewFilesPanel/index.js
@@ -360,6 +360,7 @@ export default inject(
     selectedFolderStore,
     dialogsStore,
     settingsStore,
+    clientLoadingStore,
   }) => {
     const {
       addFileToRecentlyViewed,


### PR DESCRIPTION
Fixed page crash when clicking on the new files icon in the menu