### PR TITLE
Fix no space left on device error GA Actions 

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -27,6 +27,16 @@ jobs:
       contents: write
       
     steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+    
       - name: Import GPG 
         uses: crazy-max/ghaction-import-gpg@v5
         id: gpg_step
@@ -88,6 +98,16 @@ jobs:
       contents: write
  
     steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+    
       - name: Import GPG 
         uses: crazy-max/ghaction-import-gpg@v5
         with: 


### PR DESCRIPTION
Fix GutHub Actions workflow error "no space left on device" which occurred while building packages