### PR TITLE
bugfix/contextmenu-offset

### DIFF
--- a/packages/common/components/Navigation/sub-components/context-btn.js
+++ b/packages/common/components/Navigation/sub-components/context-btn.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import VerticalDotsReactSvgUrl from "PUBLIC_DIR/images/vertical-dots.react.svg?url";
 import IconButton from "@docspace/components/icon-button";
 import ContextMenu from "@docspace/components/context-menu";
+import { isDesktop } from "@docspace/components/utils/device";
 
 const ContextButton = (props) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -41,7 +42,7 @@ const ContextButton = (props) => {
         ref={menuRef}
         onHide={onHide}
         scaled={false}
-        leftOffset={150}
+        leftOffset={isDesktop() ? 150 : 0}
       />
     </div>
   );


### PR DESCRIPTION
- Fixed bug when contextmenu in navigation opens in wrong place on tablet and mobile screens

<img width="344" alt="Screenshot 2023-08-25 155215" src="https://github.com/ONLYOFFICE/DocSpace/assets/49026407/ae1537ec-bfa6-4b3b-b6ce-5f41e9ee658e">
<img width="823" alt="Screenshot 2023-08-25 154940" src="https://github.com/ONLYOFFICE/DocSpace/assets/49026407/f24cf311-ae5e-409b-8f83-ec847d262954">
