### PR TITLE
Fix zap scanner

### DIFF
--- a/.github/workflows/zap-scan.yaml
+++ b/.github/workflows/zap-scan.yaml
@@ -54,7 +54,7 @@ jobs:
 
            # Replace SSL certs
            sudo cp ${{ github.workspace }}/onlyofficekey.pem ${{ github.workspace }}/onlyofficecert.pem /app/onlyoffice/
-           sudo bash /app/onlyoffice/config/docspace-ssl-setup -f /app/onlyoffice/onlyofficecert.pem /app/onlyoffice/onlyofficekey.pem
+           sudo bash /app/onlyoffice/config/docspace-ssl-setup -f zapdocspace.com /app/onlyoffice/onlyofficecert.pem /app/onlyoffice/onlyofficekey.pem
            sleep 60
 
            # Get Wizzard token and pwd hash for complete wizzard

--- a/.github/workflows/zap-scan.yaml
+++ b/.github/workflows/zap-scan.yaml
@@ -45,7 +45,7 @@ jobs:
            openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 \
                                                           -keyout ${{ github.workspace }}/onlyofficekey.pem \
                                                           -out ${{ github.workspace }}/onlyofficecert.pem \
-                                                          -subj "/C=RU/ST=NizhObl/L=NizhNov/O=RK-Tech/OU=TestUnit/CN=docspace.local"
+                                                          -subj "/C=RU/ST=NizhObl/L=NizhNov/O=RK-Tech/OU=TestUnit/CN=docspace.localhost"
            
            # Run 4testing DocSpace with tag from previous build
            cd ./build-tools/install/OneClickInstall
@@ -54,7 +54,7 @@ jobs:
 
            # Replace SSL certs
            sudo cp ${{ github.workspace }}/onlyofficekey.pem ${{ github.workspace }}/onlyofficecert.pem /app/onlyoffice/
-           sudo bash /app/onlyoffice/config/docspace-ssl-setup -f docspace.local /app/onlyoffice/onlyofficecert.pem /app/onlyoffice/onlyofficekey.pem
+           sudo bash /app/onlyoffice/config/docspace-ssl-setup -f docspace.localhost /app/onlyoffice/onlyofficecert.pem /app/onlyoffice/onlyofficekey.pem
            sleep 60
 
            # Get Wizzard token and pwd hash for complete wizzard

--- a/.github/workflows/zap-scan.yaml
+++ b/.github/workflows/zap-scan.yaml
@@ -45,7 +45,7 @@ jobs:
            openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 \
                                                           -keyout ${{ github.workspace }}/onlyofficekey.pem \
                                                           -out ${{ github.workspace }}/onlyofficecert.pem \
-                                                          -subj "/C=RU/ST=NizhObl/L=NizhNov/O=RK-Tech/OU=TestUnit/CN=TestName"
+                                                          -subj "/C=RU/ST=NizhObl/L=NizhNov/O=RK-Tech/OU=TestUnit/CN=docspace.local"
            
            # Run 4testing DocSpace with tag from previous build
            cd ./build-tools/install/OneClickInstall
@@ -54,7 +54,7 @@ jobs:
 
            # Replace SSL certs
            sudo cp ${{ github.workspace }}/onlyofficekey.pem ${{ github.workspace }}/onlyofficecert.pem /app/onlyoffice/
-           sudo bash /app/onlyoffice/config/docspace-ssl-setup -f zapdocspace.com /app/onlyoffice/onlyofficecert.pem /app/onlyoffice/onlyofficekey.pem
+           sudo bash /app/onlyoffice/config/docspace-ssl-setup -f docspace.local /app/onlyoffice/onlyofficecert.pem /app/onlyoffice/onlyofficekey.pem
            sleep 60
 
            # Get Wizzard token and pwd hash for complete wizzard


### PR DESCRIPTION
Add test-domain cos ssl script for docker was updated and required domain now
[Ref changes](https://github.com/ONLYOFFICE/DocSpace-buildtools/pull/62/files#diff-6a1750db06b5917ed76617a6cb0c3534d176972279d5dec2bf3eda9f7d60207bR49)